### PR TITLE
exclude cordoned nodes while scheduling

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -32,7 +32,7 @@ type kv struct {
 	Value int64
 }
 
-// getNodeList gets the nodelist which satisfies the topology info
+// getNodeList gets the nodelist which satisfies the topology info, excludes cordoned nodes.
 func getNodeList(topo []*csi.Topology) ([]string, error) {
 
 	var nodelist []string
@@ -43,17 +43,19 @@ func getNodeList(topo []*csi.Topology) ([]string, error) {
 	}
 
 	for _, node := range list.Items {
-		for _, prf := range topo {
-			nodeFiltered := false
-			for key, value := range prf.Segments {
-				if node.Labels[key] != value {
-					nodeFiltered = true
+		if !node.Spec.Unschedulable {
+			for _, prf := range topo {
+				nodeFiltered := false
+				for key, value := range prf.Segments {
+					if node.Labels[key] != value {
+						nodeFiltered = true
+						break
+					}
+				}
+				if !nodeFiltered {
+					nodelist = append(nodelist, node.Name)
 					break
 				}
-			}
-			if !nodeFiltered {
-				nodelist = append(nodelist, node.Name)
-				break
 			}
 		}
 	}


### PR DESCRIPTION
**What this PR does**:
This PR adds a check in scheduler to filter cordoned k8s node. For localpv, we should not schedule volume cr(lvmvolume, zfsvolume) on cordoned node as App will not be scedulable there. Pod gets stuck in `Pending`

**Which issue(s) this PR fixes**:
https://github.com/openebs/lvm-localpv/issues/366

