### PR TITLE
build: bump go to go1.24.12

### DIFF
--- a/.github/workflows/golang-ci.yml
+++ b/.github/workflows/golang-ci.yml
@@ -1,18 +1,3 @@
-
-# Copyright 2020 The OpenEBS Authors. All rights reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 name: golangci-lint
 on: [push, pull_request]
 jobs:
@@ -23,7 +8,8 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.24.7'
+          go-version: '1.24.12'
+
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,18 +1,3 @@
-
-# Copyright 2020 The OpenEBS Authors. All rights reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 name: Test
 on: [push, pull_request]
 jobs:
@@ -25,7 +10,7 @@ jobs:
     - uses: actions/checkout@v5
     - uses: actions/setup-go@v6
       with:
-        go-version: '1.24.7'
+        go-version: '1.24.12'
 
     - name: verify license
       run: make license-check

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/openebs/lib-csi
 
-go 1.24.0
-
-toolchain go1.24.7
+go 1.24.12
 
 require (
 	github.com/container-storage-interface/spec v1.11.0


### PR DESCRIPTION
This bumps the go patch to the latest on for 1.24, i.e. 1.24.12.